### PR TITLE
Include sha in file info in diff

### DIFF
--- a/lib/diff.js
+++ b/lib/diff.js
@@ -56,6 +56,7 @@ function getInfo(patch){
         return {
             'status': status,
             'path': file.path(),
+            'sha': file.id().tostrS(),
             'size': file.size()
         };
     })


### PR DESCRIPTION
I was glad to find a way to get a diff between a pair of commits using nodegit, but I also needed the sha of the changed files, so I had to make this modification.