### PR TITLE
Adding max-count option

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -20,7 +20,7 @@ module.exports = function(repo, o){
         'sort': o.sort in order ? order[o.sort] : o.sort,
         'abbrev': o.abbrev || null,
         'abbrev-commit': o['abbrev-commit'] || false,
-        'max-count': Infinity // TODO: document
+        'max-count': o['max-count'] || Infinity
     };
 
     return repo.getBranchCommit(o.branch || 'master')

--- a/readme.md
+++ b/readme.md
@@ -138,6 +138,7 @@ Returns an Array of all commits.
   - `sort` String can be 'none', 'topological', 'time' or 'reverse'
   - `abbrev-commit` Boolean if true shortens checksum, defaults to false
   - `abbrev` Number to specify a custom number of digits in combination with `abbrev-commit`, otherwise uses 'core.abbrev' config
+  - `max-count` Max number of commits to traverse
 
 ```javascript
 git.open('../repo-path/new/or/existing')


### PR DESCRIPTION
I found if there are many commits, git.log can be super slow.
I added this optional max-count to make it a lot faster.